### PR TITLE
Add bottr as alias command

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/Bottr-js/Bottr-CLI#readme",
   "bin": {
-    "bottr-cli": "./index.js"
+    "bottr-cli": "./index.js",
+    "bottr": "./index.js"
   }
 }


### PR DESCRIPTION
This will make `bottr` (alias of `bottr-cli) available as a new command for the CLI. (Bottr-js/Bottr#21)
