### PR TITLE
fix: suppress errors when .env does not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,11 +59,11 @@ function loadEnvFile() {
           if (err) throw err
 
           console.log('Copied .env...')
-          require('dotenv').config()
+          require('dotenv').config({silent: true})
         })
       })
     } else {
-      require('dotenv').config()
+      require('dotenv').config({silent: true})
     }
   })
 }


### PR DESCRIPTION
Hi,
I was planning to add this to the existing version on npm, but when I open the repository, I saw it's already changed. Anyways, in any case, it's good to have this config because otherwise, you might end up with ENOENT errors which is not even related to you and your work.

Thanks in advance!